### PR TITLE
Adding functionality so that a user can directly generate webm from a YouTube video

### DIFF
--- a/localizations/en_us.json
+++ b/localizations/en_us.json
@@ -5,7 +5,7 @@
 	"change_options_k": "To change any options (all of which except the keyframe file are optional), press the corresponding button. When you are done, press enter.",
 	"current_arg_values": "currently set argument values:",
 	"enter_arg_value": "Please enter your desired value for the argument \"{arg}\", then press enter to confirm. Escape to Cancel.",
-	"enter_file_path": "Please enter the path to the file you wish to convert (including file name and, if applicable, extension)",
+	"enter_file_path": "Please enter the path to the file you wish to convert (including file name and, if applicable, extension) OR enter the link to the YouTube video.",
 	"review_settings": "These are the settings you selected. If you want to proceed, press Enter. If not, exit the program (Q or Ctrl+C)",
 	"r_s_mode": "Mode:",
 	"r_s_args": "Modified Arguments:",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "webm-maker-thing-idk",
 			"version": "1.0.0",
 			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"ytdl-core": "^4.11.0"
+			},
 			"devDependencies": {
 				"eslint": "^8.20.0",
 				"prettier": "2.7.1",
@@ -897,6 +900,18 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"node_modules/m3u8stream": {
+			"version": "0.8.6",
+			"resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+			"integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+			"dependencies": {
+				"miniget": "^4.2.2",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -917,6 +932,14 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/miniget": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.2.tgz",
+			"integrity": "sha512-a7voNL1N5lDMxvTMExOkg+Fq89jM2vY8pAi9ZEWzZtfNmdfP6RXkvUtFnCAXoCv2T9k1v/fUJVaAEuepGcvLYA==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/minimatch": {
@@ -1234,6 +1257,11 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -1455,6 +1483,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ytdl-core": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.0.tgz",
+			"integrity": "sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==",
+			"dependencies": {
+				"m3u8stream": "^0.8.6",
+				"miniget": "^4.2.2",
+				"sax": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		}
 	},
@@ -2139,6 +2180,15 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"m3u8stream": {
+			"version": "0.8.6",
+			"resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+			"integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+			"requires": {
+				"miniget": "^4.2.2",
+				"sax": "^1.2.4"
+			}
+		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2154,6 +2204,11 @@
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
 			}
+		},
+		"miniget": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.2.tgz",
+			"integrity": "sha512-a7voNL1N5lDMxvTMExOkg+Fq89jM2vY8pAi9ZEWzZtfNmdfP6RXkvUtFnCAXoCv2T9k1v/fUJVaAEuepGcvLYA=="
 		},
 		"minimatch": {
 			"version": "3.1.2",
@@ -2360,6 +2415,11 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -2525,6 +2585,16 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
+		},
+		"ytdl-core": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.0.tgz",
+			"integrity": "sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==",
+			"requires": {
+				"m3u8stream": "^0.8.6",
+				"miniget": "^4.2.2",
+				"sax": "^1.1.3"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
 		"eslint": "^8.20.0",
 		"prettier": "2.7.1",
 		"terminal-kit": "^2.5.1"
+	},
+	"dependencies": {
+		"ytdl-core": "^4.11.0"
 	}
 }

--- a/terminal-ui.js
+++ b/terminal-ui.js
@@ -174,9 +174,12 @@ term.on('key', (name) => {
 			if (!flags['--angle']) flags['--angle'] = 360
 			if (!flags['--compression']) flags['--compression'] = 0
 			if (!flags['--output'])
-				// not perfect, but works well enough
-				flags['--output'] = `${path.join(path.dirname(filename), getFileName(filename))}_${modeList[selectedMode]}.webm`
-
+				if (isValidHttpUrl(filename)) {
+					flags['--output'] = `${path.join(__dirname, getFileName(filename))}_${modeList[selectedMode]}.webm`
+				} else {
+					// not perfect, but works well enough
+					flags['--output'] = `${path.join(path.dirname(filename), getFileName(filename))}_${modeList[selectedMode]}.webm`
+				}
 			mainTask = main([modeList[selectedMode]], filename, flags['--keyframes'], flags['--bitrate'], flags['--thread'], flags['--tempo'], flags['--angle'], flags['--compression'], flags['--output'])
 		}
 	} else if (stage === 5) {

--- a/terminal-ui.js
+++ b/terminal-ui.js
@@ -11,7 +11,7 @@ if (process.argv.length > 2) setLocale(process.argv[2])
 const { terminal: term } = require('terminal-kit')
 const path = require('path')
 const { modes, args, main } = require('./wackywebm.js')
-const { getFileName } = require('./util')
+const { getFileName, isValidHttpUrl } = require('./util')
 const fs = require('fs')
 
 // 0: select locale
@@ -103,15 +103,6 @@ const redrawStage5 = async () => {
 		term('\n\n\n')
 		term.bold.underline(localizeString('tui_done'))
 	}
-}
-
-// Checks if a URL provided is a valid YouTube URL
-function isValidHttpUrl(url) {
-	var regex = /^(?:https?:\/\/)?(?:m\.|www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
-	if (url.match(regex)) {
-		return url.match(regex)[1]
-	}
-	return false
 }
 
 term.on('key', (name) => {

--- a/util.js
+++ b/util.js
@@ -42,7 +42,10 @@ async function getAudioLevelMap(videoPath) {
 	return intermediateMap
 }
 
-const getFileName = (p) => path.basename(p, path.extname(p))
+const getFileName = (p) => {
+	if (isValidHttpUrl(p)) return 'youtube_download'
+	else return path.basename(p, path.extname(p))
+}
 
 // Checks if a URL provided is a valid YouTube and HTTP URL
 const isValidHttpUrl = (url) => {

--- a/util.js
+++ b/util.js
@@ -12,7 +12,7 @@ const delta = 1
 // this will make it Javascript's negative infinity.
 // dont export this (yet), we dont need it anywhere except getAudioLevelMap currently
 //const resolveNumber = (n) => (isNaN(Number(n)) ? Number.NEGATIVE_INFINITY : Number(n))
-const resolveNumber = (n, d = Number.NEGATIVE_INFINITY) => isFinite(n) ? Number(n) : d
+const resolveNumber = (n, d = Number.NEGATIVE_INFINITY) => (isFinite(n) ? Number(n) : d)
 
 const execSync = util.promisify(require('child_process').exec)
 // Obtains a map of the audio levels in decibels from the input file.
@@ -37,12 +37,21 @@ async function getAudioLevelMap(videoPath) {
 	for (const frame of intermediateMap) {
 		const clamped = Math.max(Math.min(frame.dBs, average + deviation), average - deviation)
 		const v = Math.abs((clamped - average) / deviation) * 0.5
-		frame.percentMax = clamped > average ? (0.5 + v) : (0.5 - v)
+		frame.percentMax = clamped > average ? 0.5 + v : 0.5 - v
 	}
 	return intermediateMap
 }
 
 const getFileName = (p) => path.basename(p, path.extname(p))
+
+// Checks if a URL provided is a valid YouTube and HTTP URL
+const isValidHttpUrl = (url) => {
+	var regex = /^(?:https?:\/\/)?(?:m\.|www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
+	if (url.match(regex)) {
+		return url.match(regex)[1]
+	}
+	return false
+}
 
 // these are lambdas so that their value updates as locale changes.
 // this is bad for performance, but we don't call warn or error nearly often enough for it to be a big problem.
@@ -53,4 +62,4 @@ const orgConsoleError = console.error
 console.warn = (m) => orgConsoleWarn(WARN(), m)
 console.error = (m) => orgConsoleError(ERROR(), m)
 
-module.exports = { delta, getAudioLevelMap, getFileName }
+module.exports = { delta, getAudioLevelMap, getFileName, isValidHttpUrl }

--- a/wackywebm.js
+++ b/wackywebm.js
@@ -12,7 +12,7 @@ const ytdl = require('ytdl-core')
 // Synchronous execution via promisify.
 const util = require('util')
 // I'll admit, inconvenient naming here.
-const { delta, getFileName } = require('./util')
+const { delta, getFileName, isValidHttpUrl } = require('./util')
 const { localizeString, setLocale } = require('./localization')
 const execAsync = util.promisify(require('child_process').exec)
 
@@ -223,15 +223,6 @@ function ffmpegErrorHandler(e) {
 			.filter((m) => !m.startsWith('  configuration:'))
 			.join('\n')
 	)
-}
-
-// Checks if a URL provided is a valid YouTube URL
-function isValidHttpUrl(url) {
-	var regex = /^(?:https?:\/\/)?(?:m\.|www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
-	if (url.match(regex)) {
-		return url.match(regex)[1]
-	}
-	return false
 }
 
 // Creates a new Promise to allow the script to wait for the


### PR DESCRIPTION
I really enjoyed using this utility but often found myself downloading videos from YouTube first and then using WackyWebM. This is why I implemented a feature that would allow the user to enter a YouTube video link in place of a file path and then generate a webm without having to manually download the YouTube video. Hope this helps!


### Demo 
[Streamable link](https://streamable.com/nt2nwa)

### Dependencies added
[ytdl-core](https://github.com/fent/node-ytdl-core): This is a script dependency so it doesn't require the user to manually download any libraries/software like ffmpeg and will be installed using the initial `npm i`.

### Note
As the YouTube video is first downloaded in the temporary folder under workLocations, once the webm is generated with no custom `--output` flag set, the webm would be deleted upon the removal of all temporary files. As a workaround, I save the converted YouTube webm in the directory of the project itself for now. If a file path is provided, then the webm is generated in the same location as implemented before. I'm open to suggestions on any better places to store the generated webm.

