### PR TITLE
bug fixes

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Print Ascii Art
 echo " 
  __          __        _       __          __  _     __  __ 


### PR DESCRIPTION
fixing a bug in fish-shell on start the script:

Failed to execute process './run.sh'. Reason:
exec: Exec format error
The file './run.sh' is marked as an executable but could not be run by the operating system.

this will also help other non POSIX compliant shells.