### PR TITLE
replace percentage signs in user input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "webm-maker-thing-idk",
+	"name": "wackywebm",
 	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "webm-maker-thing-idk",
+			"name": "wackywebm",
 			"version": "1.0.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -15,6 +15,10 @@
 				"eslint": "^8.20.0",
 				"prettier": "2.7.1",
 				"terminal-kit": "^2.5.1"
+			},
+			"engines": {
+				"node": ">=16.15.0",
+				"npm": ">=8.17.0"
 			}
 		},
 		"node_modules/@cronvel/get-pixels": {

--- a/terminal-ui.js
+++ b/terminal-ui.js
@@ -61,15 +61,15 @@ const redrawStage2 = () => {
 		// trouble for the marginal benefit, considering how rarely new ones get added.
 		for (const key of Object.keys(keysToFlags)) {
 			term.italic(key)
-			term(`: ${args.filter(a => a.keys.includes(keysToFlags[key]))[0].description}\n`)
+			term(`: ${args.filter(a => a.keys.includes(keysToFlags[key]))[0].description.replace(/%/g, '%%')}\n`)
 		}
 
 		term.bold.underline(`\n${localizeString('current_arg_values')}\n`)
 		for (const flag of Object.keys(flags))
-			term(`${flag} = "${flags[flag]}"\n`)
+			term(`${flag} = "${flags[flag].replace(/%/g, '%%')}"\n`)
 	} else {
 		term.bold.underline(`${localizeString('enter_arg_value', { arg: currentEdit })}\n`)
-		term.italic(currentText)
+		term.italic(currentText.replace(/%/g, '%%'))
 	}
 
 }
@@ -79,7 +79,7 @@ const redrawStage3 = () => {
 	term.clear()
 	term.bold.underline(`${localizeString('enter_file_path')}\n\n`)
 	editingText = true
-	term(filename)
+	term(filename.replace(/%/g, '%%'))
 }
 
 const redrawStage4 = () => {
@@ -91,10 +91,10 @@ const redrawStage4 = () => {
 	term('\n')
 	for (let argName of Object.keys(flags)) {
 		term.italic(`\t${argName}: `)
-		term(flags[argName] + '\n')
+		term(flags[argName].replace(/%/g, '%%') + '\n')
 	}
 	term.underline(localizeString('r_s_file'))
-	term(` ${filename}\n`)
+	term(` ${filename.replace(/%/g, '%%')}\n`)
 }
 
 let mainTask


### PR DESCRIPTION
previously, when entering a file name that contains percentage signs (`%`), they would be treated as a placeholder (for example `%s` would be displayed as `(undefined)`). this fixes that.

It's worth noting that, even previously, this was just a display bug - the actual value (and therefore the one that was used) was correct and contained, in the above example, a literal `%s`, it just messed up the printing.