### PR TITLE
Check for dependencies and direct the user to install them if not present

### DIFF
--- a/wackywebm.js
+++ b/wackywebm.js
@@ -13,6 +13,17 @@ const util = require('util')
 const { getFileName, findMinimumNonErrorSize } = require('./util')
 const { localizeString, setLocale } = require('./localization')
 const execAsync = util.promisify(require('child_process').exec)
+
+if (!fs.existsSync(__dirname + "/node_modules")) {
+	console.log("You haven't installed the nececary dependencies yet!\nPlease run \"npm install\" in the same folder as wackywebm.js and try again.");
+	// Alternatively, we could have it automatically install dependencies for the user.
+	/*(async () => {
+		await execAsync(`cd ${__dirname} && npm i`);
+		// Restart the program somehow
+	})();*/
+	return;
+}
+
 const UPNG = require("upng-js")
 
 const modes = {}

--- a/wackywebm.js
+++ b/wackywebm.js
@@ -14,14 +14,14 @@ const { getFileName, findMinimumNonErrorSize } = require('./util')
 const { localizeString, setLocale } = require('./localization')
 const execAsync = util.promisify(require('child_process').exec)
 
-if (!fs.existsSync(__dirname + "/node_modules")) {
-	console.log("You haven't installed the nececary dependencies yet!\nPlease run \"npm install\" in the same folder as wackywebm.js and try again.");
+if (!fs.existsSync(path.join(__dirname, "node_modules"))) {
+	console.log("You haven't installed the nececary dependencies yet!\nPlease run \"npm install\" in the same folder as wackywebm.js and try again.")
 	// Alternatively, we could have it automatically install dependencies for the user.
 	/*(async () => {
-		await execAsync(`cd ${__dirname} && npm i`);
+		await execAsync(`cd ${__dirname} && npm i`)
 		// Restart the program somehow
 	})();*/
-	return;
+	return
 }
 
 const UPNG = require("upng-js")


### PR DESCRIPTION
I'm back from the dead, here's a pull request.

Right now, it just checks if there is a node_modules folder, and if there is not, it stops the program and directs the user to type `npm install`, but it may be possible to automatically install them in the future.

Either way, this will solve a massive issue with people not reading the readme then asking in support.